### PR TITLE
Fix WiFi SSID regex for some serial numbers

### DIFF
--- a/libdyson/utils.py
+++ b/libdyson/utils.py
@@ -32,13 +32,13 @@ def get_mqtt_info_from_wifi_info(
     wifi_ssid: str, wifi_password: str
 ) -> Tuple[str, str, str]:
     """Get MQTT information from WiFi information."""
-    result = re.match(r"^(360EYE-)?(?P<serial>[0-9A-Z]{3}-[A-Z]{2}-[0-9A-Z]{8})$", wifi_ssid)
+    result = re.match(r"^(360EYE-)?(?P<serial>[0-9A-Z]{3}-[A-Z]{2}-[0-9A-Z]{8,})$", wifi_ssid)
     if result is not None:
         serial = result.group("serial")
         device_type = DEVICE_TYPE_360_EYE
     else:
         result = re.match(
-            r"^DYSON-([0-9A-Z]{3}-[A-Z]{2}-[0-9A-Z]{8})-([0-9]{3}[A-Z]?)$", wifi_ssid
+            r"^DYSON-([0-9A-Z]{3}-[A-Z]{2}-[0-9A-Z]{8,})-([0-9]{3}[A-Z]?)$", wifi_ssid
         )
         if result is not None:
             serial = result.group(1)


### PR DESCRIPTION
- Fixes the WiFi SSID parsing regex to allow more than 8 characters for the serial number (but still require 8)

This fix was required to get a european Dyson Pure Cool Link (TP02) to successfully parse the credential. It had a 9-digit serial number. Assuming this might happen for 360Eye devices too, the fix was also extended to that regex.